### PR TITLE
add doc resource

### DIFF
--- a/priv/documentation_style.css
+++ b/priv/documentation_style.css
@@ -1,0 +1,212 @@
+/* https://github.com/markdowncss/air MIT License*/
+@media print {
+  *,
+  *:before,
+  *:after {
+    background: transparent !important;
+    color: #000 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+}
+
+html {
+  font-size: 12px;
+}
+
+@media screen and (min-width: 32rem) and (max-width: 48rem) {
+  html {
+    font-size: 15px;
+  }
+}
+
+@media screen and (min-width: 48rem) {
+  html {
+    font-size: 16px;
+  }
+}
+
+body {
+  line-height: 1.35;
+}
+
+required {
+  color: #DC143C;
+}
+
+box {
+  border-radius: 15px;
+  background: #F0F8FF;
+  padding: 6px;
+  box-shadow: 0 0 5px;
+  height: 100px;
+}
+p,
+.air-p {
+  font-size: 1rem;
+  margin-bottom: 1.3rem;
+}
+
+h1,
+.air-h1,
+h2,
+.air-h2,
+h3,
+.air-h3,
+h4,
+.air-h4 {
+  margin: 1.414rem 0 .5rem;
+  font-weight: inherit;
+  line-height: 1.42;
+}
+
+h1,
+.air-h1 {
+  margin-top: 0;
+  font-size: 3rem;
+}
+
+h2,
+.air-h2 {
+  font-size: 2rem;
+}
+
+h3,
+.air-h3 {
+  font-size: 1.6rem;
+}
+
+h4,
+.air-h4 {
+  font-size: 1.114rem;
+}
+
+h5,
+.air-h5 {
+  font-size: 1.121rem;
+}
+
+h6,
+.air-h6 {
+  font-size: .88rem;
+}
+
+small,
+.air-small {
+  font-size: .707em;
+}
+
+/* https://github.com/mrmrs/fluidity */
+
+img,
+canvas,
+iframe,
+video,
+svg,
+select,
+textarea {
+  max-width: 100%;
+}
+
+@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,300);
+
+body {
+  color: #444;
+  font-family: 'Open Sans', Helvetica, sans-serif;
+  font-weight: 300;
+  margin: 6rem 10rem 1rem;
+  max-width: 48rem;
+  text-align: left;
+}
+
+img {
+  border-radius: 50%;
+  height: 200px;
+  margin: 0 auto;
+  width: 200px;
+}
+
+a,
+a:visited {
+  color: #3498db;
+}
+
+a:hover,
+a:focus,
+a:active {
+  color: #2980b9;
+}
+
+pre {
+  background-color: #fafafa;
+  padding: 1rem;
+  width: fit-content;
+  text-align: left;
+}
+
+blockquote {
+  margin: 0;
+  border-left: 5px solid #7a7a7a;
+  font-style: italic;
+  padding: 1.33em;
+  text-align: left;
+}
+
+ul,
+ol,
+li {
+  text-align: left;
+}
+
+p {
+  color: #777;
+}

--- a/src/decirest.erl
+++ b/src/decirest.erl
@@ -272,7 +272,7 @@ get_data(Key, Module, State, Default) ->
     #{Key := Val} ->
       Val;
     #{} = Data ->
-      case proplists:get_value(inu:t2b(Key), [{inu:t2b(K), K} || K <- maps:keys(Data)]) of
+      case proplists:get_value(t2b(Key), [{t2b(K), K} || K <- maps:keys(Data)]) of
         undefined ->
           Default;
         RawKey ->

--- a/src/decirest_app.erl
+++ b/src/decirest_app.erl
@@ -6,7 +6,7 @@
 
 -spec start(_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.
 start(_Type, _Args) ->
-	Handlers = [decirest_single_handler, decirest_collection_handler, decirest_ws_handler],
+	Handlers = [decirest_single_handler, decirest_collection_handler, decirest_ws_handler, decirest_doc_resource],
 	[Handler:module_info() || Handler <- Handlers],
 	decirest_sup:start_link().
 

--- a/src/decirest_doc_lib.erl
+++ b/src/decirest_doc_lib.erl
@@ -60,7 +60,7 @@ fetch_info(Module, Handler, HandlerOpts, Req, State0) ->
     allowed_methods => AM,
     content_types_allowed => fix_content_type(CTA),
     content_types_provided => fix_content_type(CTP),
-    children => ChildUrls
+    children => maps:values(ChildUrls)
   }.
 
 get_all_model_routes(Ref) ->

--- a/src/decirest_doc_lib.erl
+++ b/src/decirest_doc_lib.erl
@@ -37,7 +37,7 @@ fetch_doc_by_path(Ref, Req, State) ->
 
 make_doc_map(Ref, Handler, HandlerOpts = #{main_module := Module}, Req, State) ->
   D0 = #{name => atom_to_binary(Module, utf8), module => Module},
-  D1 = maps:merge(D0, fetch_info(Handler, HandlerOpts, Req, State)),
+  D1 = maps:merge(D0, fetch_info(Module, Handler, HandlerOpts, Req, State)),
 
   D2 =
     case erlang:function_exported(Module, doc, 1) of
@@ -50,7 +50,7 @@ make_doc_map(Ref, Handler, HandlerOpts = #{main_module := Module}, Req, State) -
   Paths = get_model_routes(Ref, Module),
   D2#{paths => Paths}.
 
-fetch_info(Handler, HandlerOpts, Req, State0 = #{module := Module}) ->
+fetch_info(Module, Handler, HandlerOpts, Req, State0) ->
   State = maps:merge(State0, HandlerOpts),
   {AM, _, _} = Handler:allowed_methods(Req, State),
   {CTA, _, _} = Handler:content_types_accepted(Req, State),
@@ -73,10 +73,6 @@ get_model_routes(Ref, Module) ->
   % we assume just one host definition for now, this needs to be relaxed
   #{env := #{dispatch := [{_, _, Paths}]}} = ranch:get_protocol_options(Ref),
   [make_presentation_path(P) || {P, _, _, #{main_module := M}} <- Paths, M == Module].
-  % case get_all_model_routes(Ref) of
-    % #{Module := Routes} -> Routes;
-    % _ -> notfound
-  % end.
 
 fix_content_type(List) ->
   [<<A/binary, "/", B/binary>> || {{A, B, _}, _} <- List].

--- a/src/decirest_doc_resource.erl
+++ b/src/decirest_doc_resource.erl
@@ -1,0 +1,161 @@
+%%%-------------------------------------------------------------------
+%%% @author mikael
+%%% @copyright (C) 2020, SIGICOM
+%%% @doc
+%%%
+%%% @end
+%%% Created : 23. Nov 2020 22:57
+%%%-------------------------------------------------------------------
+-module(decirest_doc_resource).
+-author("jso").
+
+%% API
+-export([
+  name/0,
+  paths/0,
+  child_of/0,
+  resource_exists/2,
+  fetch_data/2,
+  to_fun/2,
+  to_html/2,
+  doc_map_to_md/1
+]).
+
+name() -> <<"documentation">>.
+
+paths() -> [
+  {"/apidoc/path/[...]", decirest_single_handler},
+  {"/apidoc/name/:name", decirest_single_handler}
+].
+
+child_of() -> [].
+
+resource_exists(Req = #{path := << "/apidoc/path", Path/binary>>}, State = #{ref := Ref, mro_call := true}) ->
+  PathDoc = decirest_doc_lib:fetch_doc_by_path(Ref, Req#{path => Path}, State),
+  parse_doc_output(PathDoc, Req, State);
+resource_exists(Req, State = #{ref := Ref, mro_call := true}) ->
+  %% fetch by name
+  Name = cowboy_req:binding(name, Req),
+  Module = get_module_from_doc_name(Ref, Name),
+  ModuleDoc = decirest_doc_lib:fetch_doc_by_module(Ref, Module, Req, State),
+  parse_doc_output(ModuleDoc, Req, State);
+resource_exists(Req, State) ->
+  {run_default, [Req, State]}.
+
+fetch_data(_Filter, #{docs := Docs}) ->
+  {ok, [Docs]}.
+
+to_fun(Req, State = #{module := Module, rstate := RState}) ->
+  #{Module := #{data := Data}} = RState,
+  Body = doc_map_to_md(Data),
+  {Body, Req, State}.
+
+to_html(Req, State) ->
+  {Body, Req, _State} = to_fun(Req, State),
+  {ok, Css} = get_css_file(),
+  PreMd = <<"<!doctype html>  <html>  <head>", "<meta charset='utf-8'/>  <title>INFRAnet API</title> <style>", Css/binary,
+    "</style> </head>  <body>  <div id='content'></div>  <pre id='raw' hidden>">>,
+  Script = <<"<script src='https://cdn.jsdelivr.net/npm/marked/marked.min.js'></script> <script>  document.getElementById('content').innerHTML =marked(document.getElementById('raw').innerHTML);</script>">>,
+  PostMd = <<"</pre>", Script/binary, "</body></html>">>,
+  {<<PreMd/binary, Body/binary, PostMd/binary>>, Req, State}.
+
+parse_doc_output(Docs = #{module := Module}, Req, #{ref := Ref} = State) ->
+  D = maps:merge(Docs, get_extra_docs(Ref, Module)),
+  TmpState = State#{docs => maybe_fix_paths(D)},
+  decirest_single_handler:resource_exists_default(Req, TmpState);
+parse_doc_output(_, Req, State) ->
+  {stop, Req, State}.
+
+get_module_from_doc_name(Ref, Name) ->
+  Modules = decirest:get_modules(Ref),
+  get_module_from_doc_name(Ref, Modules, Name).
+
+get_module_from_doc_name(Ref, [Module | Modules], Name) ->
+  case decirest:apply_with_default(Module, doc, [], #{name => decirest:t2b(Module)}) of
+    #{name := Name} ->
+      Module;
+    _ ->
+      get_module_from_doc_name(Ref, Modules, Name)
+  end;
+get_module_from_doc_name(Ref, [], _Name) ->
+  undefined.
+
+get_css_file() ->
+  Path = code:priv_dir(decirest),
+  F = filename:join([Path, "documentation_style.css"]),
+  file:read_file(F).
+
+get_extra_docs(Ref, Module) ->
+  case code:priv_dir(Ref) of
+    {error, _} ->
+      lager:critical("no priv dir for ~p", [Ref]),
+      #{};
+    Path ->
+      F = filename:join([Path, "doc", [atom_to_list(Module) |".md"]]),
+      case file:read_file(F) of
+        {error, _} ->
+          lager:critical("no data, ~p", [F]),
+          #{};
+        {ok, Markdown} ->
+          #{markdown_extra => Markdown}
+      end
+  end.
+
+maybe_fix_paths(Map = #{paths := Paths}) ->
+  Map#{paths => [P || P = <<"/api", _/binary>> <- Paths]};
+maybe_fix_paths(Map) ->
+  Map.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%                                                                       %%
+%%                          Markdown generation                          %%
+%%                                                                       %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+doc_map_to_md(Map = #{name := Name}) ->
+  Sections = [
+    {description, fun desc_md/1},
+    {allowed_methods, fun am_md/1},
+    {paths, fun paths_md/1},
+    {content_types_provided, fun ctp_md/1},
+    {content_types_accepted, fun cta_md/1},
+    {schema, fun decirest_schema:schema_to_md/1},
+    {children, fun children_md/1},
+    {markdown_extra, fun extra_md/1}
+  ],
+  doc_map_to_md(Sections, Map, [<<"Resource documentation: ", Name/binary, "\n===\n\n">>]).
+
+
+doc_map_to_md([{Section, Fun} | Sections], Map, Body) ->
+  case Map of
+    #{Section := Data} ->
+      doc_map_to_md(Sections, Map, [Body | [Fun(Data), <<"\n">>]]);
+    _ ->
+      doc_map_to_md(Sections, Map, Body)
+  end;
+doc_map_to_md([], _Map, Body) ->
+  iolist_to_binary(Body).
+
+desc_md(Data) ->
+  [<<"Description\n---\n">>, Data, <<"\n">>].
+
+am_md(Data) ->
+  [<<"Allowed methods\n---\n">>, md_list(Data)].
+
+paths_md(Data) ->
+  ["Paths\n---\n", md_list(Data)].
+
+ctp_md(Data) ->
+  [<<"Content-Type provided\n---\n">>, md_list(Data)].
+
+cta_md(Data) ->
+  [<<"Content-Type accepted\n---\n">>, md_list(Data)].
+
+children_md(Data) ->
+  [<<"Child resource\n---\n">>, jiffy:encode(Data, [pretty]), <<"\n">>].
+
+extra_md(Data) ->
+  Data.
+
+md_list(DataList) ->
+  [["* ", Data, "\n"]  || Data <- DataList].

--- a/src/decirest_doc_resource.erl
+++ b/src/decirest_doc_resource.erl
@@ -53,7 +53,7 @@ to_fun(Req, State = #{module := Module, rstate := RState}) ->
 to_html(Req, State) ->
   {Body, Req, _State} = to_fun(Req, State),
   {ok, Css} = get_css_file(),
-  PreMd = <<"<!doctype html>  <html>  <head>", "<meta charset='utf-8'/>  <title>INFRAnet API</title> <style>", Css/binary,
+  PreMd = <<"<!doctype html>  <html>  <head>", "<meta charset='utf-8'/>  <title>API DOC</title> <style>", Css/binary,
     "</style> </head>  <body>  <div id='content'></div>  <pre id='raw' hidden>">>,
   Script = <<"<script src='https://cdn.jsdelivr.net/npm/marked/marked.min.js'></script> <script>  document.getElementById('content').innerHTML =marked(document.getElementById('raw').innerHTML);</script>">>,
   PostMd = <<"</pre>", Script/binary, "</body></html>">>,
@@ -120,7 +120,7 @@ doc_map_to_md(Map = #{name := Name}) ->
     {content_types_provided, fun ctp_md/1},
     {content_types_accepted, fun cta_md/1},
     {schema, fun decirest_schema:schema_to_md/1},
-    {children, fun children_md/1},
+    {children, children_md(Name)},
     {markdown_extra, fun extra_md/1}
   ],
   doc_map_to_md(Sections, Map, [<<"Resource documentation: ", Name/binary, "\n===\n\n">>]).
@@ -142,8 +142,8 @@ desc_md(Data) ->
 am_md(Data) ->
   [<<"Allowed methods\n---\n">>, md_list(Data)].
 
-paths_md(Data) ->
-  ["Paths\n---\n", md_list(Data)].
+paths_md(Paths) ->
+  ["Paths\n---\n", md_link_list(Paths)].
 
 ctp_md(Data) ->
   [<<"Content-Type provided\n---\n">>, md_list(Data)].
@@ -151,11 +151,16 @@ ctp_md(Data) ->
 cta_md(Data) ->
   [<<"Content-Type accepted\n---\n">>, md_list(Data)].
 
-children_md(Data) ->
-  [<<"Child resource\n---\n">>, jiffy:encode(Data, [pretty]), <<"\n">>].
+children_md(Name) ->
+  fun(ChildUrls) ->
+    [<<"Child resources\n---\n">>, md_link_list(ChildUrls)]
+  end.
 
 extra_md(Data) ->
   Data.
+
+md_link_list(DataList) ->
+  [["* [", Data, "](/apidoc/path", Data,  ") \n"]  || Data <- DataList].
 
 md_list(DataList) ->
   [["* ", Data, "\n"]  || Data <- DataList].

--- a/src/decirest_schema.erl
+++ b/src/decirest_schema.erl
@@ -1,0 +1,79 @@
+%%%-------------------------------------------------------------------
+%%% @author jonathan
+%%% @copyright (C) 2020
+%%% @doc
+%%%
+%%% @end
+%%% Created : 26. Oct 2020 20:14
+%%%-------------------------------------------------------------------
+-module(decirest_schema).
+-author("jonathan").
+
+%% API
+-export([schema_to_md/1]).
+
+schema_to_md(Json) ->
+  [[<<"Schema\n---\n">>, pretty_prop({undefined, Json}, #{level => 0, required => []})]].
+
+pretty_prop({Property, Json}, #{level := Level, required := Required}) ->
+  {Indentation, ListSymbol} = style_level(Level),
+  Default =  maps:get(<<"default">>, Json, undefined),
+  Type = maps:get(<<"type">>, Json, <<"object">>),
+  RequiredProps = get_required_properties(Type, Json),
+  Properties = get_properties(Type, Json),
+  List = maps:get(<<"enum">>, Json, []),
+
+  DescriptionMd = get_description_md(maps:get(<<"description">>, Json, undefined), Indentation),
+  TitleMd = get_title_md(Property, Json, Required),
+  TypeMd = [<<"\n">>, Indentation, <<"*type*: ">>, Type, <<"\n">>],
+  DefaultMd = get_default_md(Default, Indentation),
+
+  PropertiesMd = [[Indentation, ListSymbol, pretty_prop(P, #{level => Level+1, required => RequiredProps})] || P <- maps:to_list(Properties)],
+  ListMd = get_list_md(List, Indentation, ListSymbol),
+
+  [<<"<box>">>, TitleMd, DescriptionMd, TypeMd, DefaultMd, ListMd, PropertiesMd, <<"</box>">>, <<"\n">>].
+
+style_level(0) ->
+  {<<"">>, <<"+ ">>};
+style_level(1) ->
+  {<<"    ">>, <<"* ">>};
+style_level(2) ->
+  {<<"        ">>, <<"- ">>}.
+
+get_required_properties(<<"array">>, Json) ->
+  maps:get(<<"required">>, maps:get(<<"items">>, Json, #{}), []);
+get_required_properties(_, Json) ->
+  maps:get(<<"required">>, Json, <<"false">>).
+
+get_properties(<<"array">>, Json) ->
+  maps:get(<<"properties">>, maps:get(<<"items">>, Json, #{}), #{});
+get_properties(_, Json) ->
+  maps:get(<<"properties">>, Json, #{}).
+
+get_title_md(undefined, Json, Required) ->
+  % assume top-level, get "title" instead
+  get_title_md(maps:get(<<"title">>, Json, <<"">>), Json, Required);
+get_title_md(Property, _Json, Required) ->
+  case lists:member(Property, Required) of
+    false ->
+      [<<"**">>, Property, <<"**">>, <<"\n">>];
+    true ->
+      [<<"**">>, Property, <<"** ">>, <<" *<required>required</required>*">>, <<"\n">>]
+  end.
+
+get_description_md(undefined, _) ->
+  [];
+get_description_md(Description, Indentation) ->
+  [<<"\n">>, Indentation, Description, <<"\n">>].
+
+get_list_md(List, Indentation, ListSymbol) ->
+  [[Indentation, ListSymbol, E, <<"\n">>] || E <- List].
+
+get_default_md(undefined, Indentation) ->
+  [];
+get_default_md(#{<<"element">> := Map}, Indentation) ->
+  [];
+%get_default_md(Map, Indentation);
+get_default_md(Any, Indentation) ->
+  Default = jiffy:encode(Any, [pretty]),
+  [<<"\n">>, Indentation, <<"*default*: ">>, Default, <<"\n">>].


### PR DESCRIPTION
Most code is taken from our internal project that use Decirest I just refactored it to be able to be generic.

Add easier way to start
```erlang
  DecirestOpt =#{state => #{decirest_auth_module => my_auth_module}},
  TransportOpt =[{port, 8081},{num_acceptors, 100}],
  decirest:start(my_app, Modules, DecirestOpt, TransportOpt).
```

Needs work on child doc before merging