### PR TITLE
Fix required_props in schema_to_md

### DIFF
--- a/src/decirest_schema.erl
+++ b/src/decirest_schema.erl
@@ -43,7 +43,7 @@ style_level(2) ->
 get_required_properties(<<"array">>, Json) ->
   maps:get(<<"required">>, maps:get(<<"items">>, Json, #{}), []);
 get_required_properties(_, Json) ->
-  maps:get(<<"required">>, Json).
+  maps:get(<<"required">>, Json, []).
 
 get_properties(<<"array">>, Json) ->
   maps:get(<<"properties">>, maps:get(<<"items">>, Json, #{}), #{});

--- a/src/decirest_schema.erl
+++ b/src/decirest_schema.erl
@@ -43,7 +43,7 @@ style_level(2) ->
 get_required_properties(<<"array">>, Json) ->
   maps:get(<<"required">>, maps:get(<<"items">>, Json, #{}), []);
 get_required_properties(_, Json) ->
-  maps:get(<<"required">>, Json, <<"false">>).
+  maps:get(<<"required">>, Json).
 
 get_properties(<<"array">>, Json) ->
   maps:get(<<"properties">>, maps:get(<<"items">>, Json, #{}), #{});


### PR DESCRIPTION
The default "false" doesn't even make sense because it's not a boolean but a list