### PR TITLE
make error return of persist_data return 500 instead of 204

### DIFF
--- a/src/decirest_collection_handler.erl
+++ b/src/decirest_collection_handler.erl
@@ -124,7 +124,7 @@ handle_body(Body, Req = #{path := Path}, State = #{module := Module}) ->
                     SelfUrl = decirest:pretty_path([Path, "/", decirest:t2b(NewID)]),
                     {{true, SelfUrl}, Req, NewState};
                 {error, NewState} ->
-                    ReqNew = decirest_req:set_resp_body(<<"error">>, Req),
+                    ReqNew = decirest_req:reply(500, #{}, <<"error">>, Req),
                     {stop, ReqNew, NewState};
                 {StatusCode, NewState} when is_number(StatusCode) ->
                     ReqNew = decirest_req:reply(StatusCode, Req),

--- a/src/decirest_single_handler.erl
+++ b/src/decirest_single_handler.erl
@@ -154,7 +154,7 @@ validate_payload(Body, Req = #{method := Method}, State) ->
             case decirest_handler_lib:persist_data(Payload, Req, State) of
                 {ok, NewState} -> {true, Req, NewState};
                 {error, NewState} ->
-                    ReqNew = decirest_req:set_resp_body(<<"error">>, Req),
+                    ReqNew = decirest_req:reply(500, #{}, <<"error">>, Req),
                     {stop, ReqNew, NewState};
                 {StatusCode, NewState} when is_number(StatusCode) ->
                     ReqNew = decirest_req:reply(StatusCode, Req),


### PR DESCRIPTION
We've noticed that when trying to persist data on an API endpoint and the `persist_data` callback fails with an `{error, State}` the API still returned a 204.
This tricked other systems to think that data was stored correctly and proceed further, although that was not the case.
This PR aims to fix this issue and instead by default return a 500 whenever `persists_data` callback returns `{error, State}`.